### PR TITLE
remove entrypoint b/c overriding it is a pain in the butt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:2.7
 ENV PYTHONUNBUFFERED 1
-WORKDIR /leaderboard
 EXPOSE 7001
-ENTRYPOINT gunicorn -b 0.0.0.0:7001 leaderboard.wsgi
+WORKDIR /leaderboard
 COPY . /leaderboard
 RUN apt-get update && apt-get install -y binutils libproj-dev gdal-bin && apt-get -y clean 
 RUN pip install -r requirements.txt --no-cache-dir --disable-pip-version-check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:2.7
 ENV PYTHONUNBUFFERED 1
-EXPOSE 7001
 WORKDIR /leaderboard
-COPY . /leaderboard
+EXPOSE 7001
 RUN apt-get update && apt-get install -y binutils libproj-dev gdal-bin && apt-get -y clean 
+COPY ./requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir --disable-pip-version-check
+COPY . /leaderboard


### PR DESCRIPTION
Since there are multiple invocations for this container, an entrypoint doesn't fit the "default" use well enough to be be used.
