### PR TITLE
sigh - tweak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR /leaderboard
 EXPOSE 7001
 RUN apt-get update && apt-get install -y binutils libproj-dev gdal-bin && apt-get -y clean 
-COPY ./requirements.txt .
+COPY ./requirements.txt ./
 RUN pip install -r requirements.txt --no-cache-dir --disable-pip-version-check
 COPY . /leaderboard


### PR DESCRIPTION
COPY ./requirements.txt . works fine on my test box (docker 1.9) but on our prod build host (1.7) it fails.