### PR TITLE
Verify client_id during authentication #245

### DIFF
--- a/leaderboard/contributors/tests/test_views.py
+++ b/leaderboard/contributors/tests/test_views.py
@@ -33,6 +33,7 @@ class SubmitContributionTests(MockRequestTestMixin, TestCase):
     def setUp(self):
         super(SubmitContributionTests, self).setUp()
         fxa_profile_data = self.setup_profile_call()
+        self.setup_verify_call(uid=fxa_profile_data['uid'])
         self.country = CountryFactory()
         self.contributor = ContributorFactory(fxa_uid=fxa_profile_data['uid'])
 

--- a/leaderboard/fxa/client.py
+++ b/leaderboard/fxa/client.py
@@ -124,6 +124,27 @@ class FXAClient(object):
 
         return self._parse_response(response)
 
+    def verify_token(self, access_token):
+        """
+        Verify an access token with FXA.
+
+        Example response:
+
+        {
+            "user": "5901bd09376fadaa076afacef5251b6a",
+            "client_id": "45defeda038a1c92",
+            "scope": ["profile:email", "profile:avatar"],
+            "email": "foo@example.com"
+        }
+        """
+        profile_url = urlparse.urljoin(settings.FXA_OAUTH_URI, 'v1/verify')
+        response = requests.post(
+            profile_url,
+            {'token': access_token},
+        )
+
+        return self._parse_response(response)
+
     def get_profile_data(self, access_token):
         """
         Retrieve the profile details for a user given a valid access_token.

--- a/leaderboard/fxa/tests/test_views.py
+++ b/leaderboard/fxa/tests/test_views.py
@@ -199,7 +199,6 @@ class TestFXARefreshView(MockRequestTestMixin, TestCase):
         response = self.client.post(
             reverse('fxa-refresh'),
             data={'refresh_token': 'asdf'},
-            HTTP_AUTHORIZATION='Bearer asdf',
         )
 
         self.assertEqual(response.status_code, 200)
@@ -207,25 +206,6 @@ class TestFXARefreshView(MockRequestTestMixin, TestCase):
         response_data = json.loads(response.content)
 
         self.assertEqual(response_data, fxa_auth_data)
-
-    def test_missing_access_token_raises_403(self):
-        response = self.client.post(
-            reverse('fxa-refresh'),
-            data={'refresh_token': 'asdf'},
-        )
-
-        self.assertEqual(response.status_code, 401)
-
-    def test_invalid_access_token_raises_403(self):
-        self.set_mock_response(self.mock_get, status_code=400)
-
-        response = self.client.post(
-            reverse('fxa-refresh'),
-            data={'refresh_token': 'asdf'},
-            HTTP_AUTHORIZATION='Bearer asdf',
-        )
-
-        self.assertEqual(response.status_code, 401)
 
     def test_missing_refresh_token_raises_400(self):
         response = self.client.post(

--- a/leaderboard/fxa/views.py
+++ b/leaderboard/fxa/views.py
@@ -10,7 +10,6 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 
 from leaderboard.contributors.models import Contributor
-from leaderboard.fxa.authenticator import OAuthTokenAuthentication
 from leaderboard.fxa.client import (
     get_fxa_login_url,
     FXAClientMixin,
@@ -96,7 +95,6 @@ class FXARedirectView(FXAClientMixin, APIView):
 
 
 class FXARefreshView(FXAClientMixin, APIView):
-    authentication_classes = (OAuthTokenAuthentication,)
 
     def post(self, request):
         refresh_token = request.POST.get('refresh_token', None)


### PR DESCRIPTION
- Add verify method to client
- Verify client_id at authentication time
- Add/update tests
- Remove unnecessary Auth header from refresh endpoint