### PR TITLE
a lot of packages are not needed post-install; remove them prior to c…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ ENV PYTHONUNBUFFERED 1
 ENV DOCKER_BUILD 1
 WORKDIR /leaderboard
 EXPOSE 7001
-RUN apt-get update && apt-get install -y binutils libproj-dev gdal-bin && apt-get -y clean 
+RUN apt-get update && apt-get install -y binutils libproj-dev gdal-bin
 COPY ./requirements.txt ./
 RUN pip install -r requirements.txt --no-cache-dir --disable-pip-version-check
 COPY . /leaderboard
 RUN ./scripts/echo_version_json.sh > /leaderboard/leaderboard/version.json
 RUN mkdir /leaderboard/leaderboard/served/;mkdir /leaderboard/leaderboard/served/static/;python manage.py collectstatic -c --noinput
+RUN apt-get -y autoremove && apt-get -y clean


### PR DESCRIPTION
…ommiting the container

The following packages were automatically installed and are no longer required:
  gir1.2-freedesktop gir1.2-gdkpixbuf-2.0 gir1.2-glib-2.0 gir1.2-rsvg-2.0 libcairo-gobject2
  libcairo-script-interpreter2 libcdt5 libcgraph6 libcroco3 libdjvulibre-dev libelfg0 libexif-dev libexif12
  libexpat1-dev libfontconfig1-dev libfreetype6-dev libgd3 libgirepository-1.0-1 libglib2.0-bin libgraphviz-dev
  libgvc6 libgvpr2 libice-dev libice6 libilmbase-dev libjasper-dev libjbig-dev libjs-excanvas libjs-jquery
  liblcms2-dev liblqr-1-0-dev liblzo2-2 libmagickcore-6-arch-config libmagickcore-6-headers libmagickwand-6-headers
  libopenexr-dev libpathplan4 libpcre3-dev libpcrecpp0 libpixman-1-dev libpng12-dev libpthread-stubs0-dev
  librsvg2-2 librsvg2-common libsm-dev libsm6 libtiff5-dev libtiffxx5 libvpx1 libwmf-dev libx11-dev libxau-dev
  libxcb-render0-dev libxcb-shm0-dev libxcb1-dev libxdmcp-dev libxdot4 libxext-dev libxpm4 libxrender-dev libxt-dev
  libxt6 mime-support pkg-config x11-common x11proto-core-dev x11proto-input-dev x11proto-kb-dev
  x11proto-render-dev x11proto-xext-dev xorg-sgml-doctools xtrans-dev
Use 'apt-get autoremove' to remove them.