### PR TITLE
Improve performance of compute_ranks country matching #282

### DIFF
--- a/leaderboard/contributors/models.py
+++ b/leaderboard/contributors/models.py
@@ -73,10 +73,20 @@ class ContributorRank(models.Model):
             # Each contribution counts towards the rank in the country in which
             # it was made, as well as the global rank for that contributor.
 
-            contribution_country = sorted([
-                (country.geometry.distance(contribution.point), country)
-                for country in countries
-            ])[0][1]
+            contribution_country = None
+
+            # Attempt to find a country which contains the observation point
+            for country in countries:
+                if country.geometry.contains(contribution.point):
+                    contribution_country = country
+                    break
+
+            # If no point was found, find the nearest country
+            if contribution_country is None:
+                contribution_country = sorted([
+                    (country.geometry.distance(contribution.point), country)
+                    for country in countries
+                ])[0][1]
 
             for country_id in (contribution_country.id, None):
                 rank_key = (contribution.contributor_id, country_id)


### PR DESCRIPTION
Rather than compare distances to every country, attempt to find a country which contains the point and fail fast.  Otherwise compute distances and find the nearest one.

I compared performance between doing this in memory and letting the database do it using st_contains, and the performance with the db was every so slightly worse than the in memory case, but only slightly.  However, reducing load on the db is a good thing, so I think doing it in memory should be fine.  This is roughly 4 times faster than simply sorting by all distances and doing no containment checks, according to my local benchmarking.