### PR TITLE
Further tweaks to compute_ranks.

### DIFF
--- a/leaderboard/contributors/models.py
+++ b/leaderboard/contributors/models.py
@@ -73,10 +73,20 @@ class ContributorRank(models.Model):
             # Each contribution counts towards the rank in the country in which
             # it was made, as well as the global rank for that contributor.
 
-            contribution_country = sorted([
-                (country.geometry.distance(contribution.point), country)
-                for country in countries
-            ])[0][1]
+            contribution_country = None
+
+            # Attempt to find a country which contains the observation point
+            for country in countries:
+                if country.geometry.contains(contribution.point):
+                    contribution_country = country
+                    break
+
+            # If no point was found, find the nearest country
+            if contribution_country is None:
+                contribution_country = sorted([
+                    (country.geometry.distance(contribution.point), country)
+                    for country in countries
+                ])[0][1]
 
             for country_id in (contribution_country.id, None):
                 rank_key = (contribution.contributor_id, country_id)


### PR DESCRIPTION
@jaredkerim 

I tried to add a couple more tweaks based on your PR, done in an extra commit:

* The country query limits the fields, so it doesn't download additional fields like iso codes, or population estimates.
* The countries are ordered by area in decreasing order instead of name. So largest areas/countries will be checked first, since those have a higher chance of containing the points.
* I've added [prepared geometries](https://docs.djangoproject.com/en/1.9/ref/contrib/gis/geos/#prepared-geometries), which should be faster at contains queries but don't support distance.

I don't have a large enough sample dataset to try this, could you sanity check that this actually improves things?