### PR TITLE
Add report only CSP header

### DIFF
--- a/leaderboard/settings.py
+++ b/leaderboard/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = (
 MIDDLEWARE_CLASSES = (
     'leaderboard.stats_middleware.StatsMiddleware',
 
+    'csp.middleware.CSPMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
@@ -77,6 +78,63 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'leaderboard.wsgi.application'
 
+# Content Security Policy
+CSP_REPORT_ONLY = True
+
+CSP_DEFAULT_SRC = (
+    "'none'",
+)
+
+CSP_SCRIPT_SRC = (
+    "'self'",
+    "'sha256-Ri/knIQy+te80bBUW2ViOjxeh+qSuEtuLCIT0mCqX7U='", # for landing.html L57 inline script window.onload = ...
+    "'sha256-K52oyFUGA5jrXpSv3mYq5eyKyH1ER3Me3vevzaHBBmM='", # for landing.html L78 GA inline script
+    "mozorg.cdn.mozilla.net",
+    "www.google-analytics.com",
+    "www.mozilla.org",
+)
+
+CSP_STYLE_SRC = (
+    "'unsafe-inline'",  # jQuery 1.7 uses inline styles
+    "'self'",
+    "www.mozilla.org",
+)
+
+CSP_IMG_SRC = (
+    "'self'",
+    "data:",
+    "*.tiles.mapbox.com",
+    "www.google-analytics.com",
+    "www.mozilla.org",
+)
+
+CSP_CONNECT_SRC = (
+    "'self'",  # API requests
+)
+
+CSP_OBJECT_SRC = (
+    "'none'",
+)
+
+CSP_FRAME_ANCESTORS = (
+    "'none'",
+)
+
+CSP_CHILD_SRC = (
+    "'none'",
+)
+
+CSP_FONT_SRC = (
+    "'self'",
+)
+
+CSP_BASE_URI = (
+    "'none'"
+)
+
+CSP_REPORT_URI = (
+    "/__cspreport__"
+)
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/leaderboard/settings.py
+++ b/leaderboard/settings.py
@@ -88,7 +88,6 @@ CSP_DEFAULT_SRC = (
 CSP_SCRIPT_SRC = (
     "'self'",
     "'sha256-Ri/knIQy+te80bBUW2ViOjxeh+qSuEtuLCIT0mCqX7U='", # for landing.html L57 inline script window.onload = ...
-    "'sha256-K52oyFUGA5jrXpSv3mYq5eyKyH1ER3Me3vevzaHBBmM='", # for landing.html L78 GA inline script
     "mozorg.cdn.mozilla.net",
     "www.google-analytics.com",
     "www.mozilla.org",

--- a/leaderboard/static/js/load_ga.js
+++ b/leaderboard/static/js/load_ga.js
@@ -1,0 +1,7 @@
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', document.getElementById('leaderboard-container').getAttribute('data-ga-id'), 'auto');
+ga('send', 'pageview');

--- a/leaderboard/templates/home/landing.html
+++ b/leaderboard/templates/home/landing.html
@@ -5,7 +5,7 @@
 {% block page_title %}{% endblock %}
 
 {% block content %}
-<div id="leaderboard-container">
+<div id="leaderboard-container" data-ga-id="{{ GOOGLE_ANALYTICS_ID }}">
 </div>
 
 <div class="section">
@@ -75,13 +75,5 @@
       }
     </script>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', '{{ GOOGLE_ANALYTICS_ID }}', 'auto');
-      ga('send', 'pageview');
-    </script>
+    <script src="{% static "js/load_ga.js" %}"></script>
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==1.8.2
 django-bulk-update==1.1.7
+django-csp==3.1
 djangorestframework-gis==0.9.2
 djangorestframework==3.1.3
 factory-boy==2.5.2


### PR DESCRIPTION
Adds a report only CSP header for #302

The report URI doesn't exist yet, but we can add that at the load balancer or reverse proxy level.

To lock this down further in future PRs we can:
- set report only false and actually enable CSP (assuming we don't get violation reports for awhile)
- add directives missing from django-csp like referrer, reflected-xss, upgrade-insecure-requests, plugin-types, strict-dynamic
- upgrade jQuery from 1.7 to a version that doesn't use inline styles

The header was generated by proxying through OWASP ZAP with the CSP helper addon to local and prod instances of location leaderboard then manually simplifying the resulting header.
