### PR TITLE
enable CSP

### DIFF
--- a/leaderboard/settings.py
+++ b/leaderboard/settings.py
@@ -79,7 +79,6 @@ TEMPLATES = [
 WSGI_APPLICATION = 'leaderboard.wsgi.application'
 
 # Content Security Policy
-CSP_REPORT_ONLY = True
 
 CSP_DEFAULT_SRC = (
     "'none'",


### PR DESCRIPTION
Enables the CSP policy added in https://github.com/mozilla-services/location-leaderboard/pull/303

If we don't have any CSP errors, since that was deployed this should be good to go.

I don't have the local environment setup, but [django-csp defaults to `CSP_REPORT_ONLY = False`](https://github.com/mozilla/django-csp/blob/master/csp/middleware.py#L42), so the header should be set properly.