### PR TITLE
add mozilla.org to CSP font-src

### DIFF
--- a/leaderboard/settings.py
+++ b/leaderboard/settings.py
@@ -125,6 +125,7 @@ CSP_CHILD_SRC = (
 
 CSP_FONT_SRC = (
     "'self'",
+    "www.mozilla.org",
 )
 
 CSP_BASE_URI = (


### PR DESCRIPTION
We have a handful of CSP errors loading https://www.mozilla.org/media/fonts/opensans-regular.woff and other fonts. 

Blocks: https://github.com/mozilla-services/location-leaderboard/pull/306