### PR TITLE
Move init JS script to separate file

### DIFF
--- a/leaderboard/settings.py
+++ b/leaderboard/settings.py
@@ -87,7 +87,6 @@ CSP_DEFAULT_SRC = (
 
 CSP_SCRIPT_SRC = (
     "'self'",
-    "'sha256-Ri/knIQy+te80bBUW2ViOjxeh+qSuEtuLCIT0mCqX7U='", # for landing.html L57 inline script window.onload = ...
     "mozorg.cdn.mozilla.net",
     "www.google-analytics.com",
     "www.mozilla.org",

--- a/leaderboard/static/js/onload.js
+++ b/leaderboard/static/js/onload.js
@@ -1,0 +1,21 @@
+window.onload = function () {
+  var getAppAttr = function (attrName) {
+      document.getElementById('leaderboard-container').getAttribute('data-' + attrName);
+  };
+
+  leaderboard.init({
+    leafletJSUrl: getAppAttr('leaflet-js-url'),
+    leafletGeometryJSUrl: getAppAttr('leaflet-geometry-js-url'),
+    leafletCSSUrl: getAppAttr('leaflet-css-url'),
+    countriesGeoUrl: getAppAttr('countries-geo-url'),
+    countriesInfoUrl: getAppAttr('countries-info-url'),
+    globalLeadersUrl: getAppAttr('global-leaders-url'),
+    countryLeadersUrl: getAppAttr('country-leaders-url'),
+    leaderProfileUrl: getAppAttr('leader-profile-url')
+  });
+
+  try {
+    Tabzilla.disableEasterEgg()
+  } catch (e) {
+  }
+}

--- a/leaderboard/templates/home/landing.html
+++ b/leaderboard/templates/home/landing.html
@@ -5,7 +5,16 @@
 {% block page_title %}{% endblock %}
 
 {% block content %}
-<div id="leaderboard-container" data-ga-id="{{ GOOGLE_ANALYTICS_ID }}">
+<div id="leaderboard-container"
+     data-ga-id="{{ GOOGLE_ANALYTICS_ID }}"
+     data-leaflet-js-url="{% static "lib/leaflet/leaflet.js" %}"
+     data-leaflet-geometry-js-url="{% static "lib/leaflet/leaflet.geometryutil.js" %}"
+     data-leaflet-css-url="{% static "lib/leaflet/leaflet.css" %}"
+     data-countries-geo-url="{% static "geojson/countries.named.geojson" %}"
+     data-countries-info-url="{% url "countries-list" %}"
+     data-global-leaders-url="{% url "leaders-global-list" %}"
+     data-country-leaders-url="{% url "leaders-country-list" country_id="XX" %}"
+     data-leader-profile-url="{% url "leaders-profile" uid="XX" %}">
 </div>
 
 <div class="section">
@@ -53,27 +62,6 @@
     <script src="{% static "js/dist/leaderboard.react.js" %}"></script>
     {% endif %}
 
-
-    <script>
-      window.onload = function () {
-        leaderboard.init({
-          leafletJSUrl: '{% static "lib/leaflet/leaflet.js" %}',
-          leafletGeometryJSUrl: '{% static "lib/leaflet/leaflet.geometryutil.js" %}',
-          leafletCSSUrl: '{% static "lib/leaflet/leaflet.css" %}',
-
-          countriesGeoUrl: '{% static "geojson/countries.named.geojson" %}',
-          countriesInfoUrl: '{% url "countries-list" %}',
-          globalLeadersUrl: '{% url "leaders-global-list" %}',
-          countryLeadersUrl: '{% url "leaders-country-list" country_id="XX" %}',
-          leaderProfileUrl: '{% url "leaders-profile" uid="XX" %}',
-        });
-
-        try {
-          Tabzilla.disableEasterEgg()
-        } catch (e) {
-        }
-      }
-    </script>
-
+    <script src="{% static "js/onload.js" %}"></script>
     <script src="{% static "js/load_ga.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
refs: #306 

To stop using CSP hash script srcs which Chrome <46 (on Android in
particular) don't support.

I haven't tested this, but the CSP header is report-only.